### PR TITLE
[issue 5] A check was added to confirm that there was only one dot in…

### DIFF
--- a/customer-new-job.php
+++ b/customer-new-job.php
@@ -45,11 +45,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       $file_name = $_FILES["3d_model"]['name'];
       $file_array = explode(".",$file_name);
       $ext = end($file_array);
-      $explode_len = count($file_array);
-      if (!in_array($ext, ["stl", "obj", "3mf", "gcode","svg"])|| $explode_len > 2) {
+	  if (!in_array($ext, ["stl", "STL", "obj", "3mf", "gcode","svg"])) {
           throw new RuntimeException('Invalid file format.');
       }
-
+	  
+	  
       // You should name it uniquely.
       // DO NOT USE $_FILES["3d_model"]['name'] WITHOUT ANY VALIDATION !!
       // On this example, obtain safe unique name from its binary data.


### PR DESCRIPTION
… the file name, removed this so the last dot denotes the file extension

Basically, there is a check in customer-create job where file names with more than one dot aren't accepted.
I removed the check and now they are. Personally I don't see this being an issue, however let me know if you have any concerns.

